### PR TITLE
Build + deploy via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          packageManager: pnpm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud Claw (Cloudflare + OpenClaw)
+# Cloud Claw (Cloudflare + OpenClaw) 
 
 **Cloud Claw** is a containerized AI assistant that runs [OpenClaw](https://github.com/openclaw/openclaw) on Cloudflare Workers + Containers.
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,6 +24,13 @@
       "custom_domain": true,
     },
   ],
+  "vars": {
+    "SERVER_USERNAME": "agili",
+    "WORKER_URL": "https://openrouter.millennials-post-covid.com",
+    "S3_ENDPOINT": "https://7018afd37571b2583d8b5866864e98fb.r2.cloudflarestorage.com",
+    "S3_BUCKET": "cloud-claw-data",
+    "S3_PREFIX": "cloud-claw",
+  },
   "browser": {
     "binding": "BROWSER",
     "remote": true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,6 +18,12 @@
   "placement": {
     "region": "aws:us-west-2",
   },
+  "routes": [
+    {
+      "pattern": "openrouter.millennials-post-covid.com",
+      "custom_domain": true,
+    },
+  ],
   "browser": {
     "binding": "BROWSER",
     "remote": true,


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` that runs on push to master.
- Uses GHA runners (lots of disk) to build the container image, then `cloudflare/wrangler-action@v3` handles deploy.
- Replaces Workers Builds, which ran out of disk exporting the OpenClaw image.

## Required repo secrets
- `CLOUDFLARE_API_TOKEN` — token with Workers Scripts:Edit, Workers Routes:Edit, Account:Read, SSL and Certificates:Edit, Containers:Edit
- `CLOUDFLARE_ACCOUNT_ID` — `7018afd37571b2583d8b5866864e98fb`

## After merge
- Disable the Workers Builds Git integration in the Cloudflare dashboard to avoid duplicate deploys.
- Close #3 (pin-container-image) — no longer needed.

## Test plan
- [ ] Add the two repo secrets
- [ ] Merge this PR
- [ ] Verify the workflow run builds + deploys successfully
- [ ] Confirm `https://openrouter.millennials-post-covid.com` still responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)