### PR TITLE
Auto-approve pending device pairing in entrypoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          packageManager: pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,8 +106,7 @@ else
 	echo "[WARN] OPENCLAW_GATEWAY_TOKEN not set, will be auto-generated"
 fi
 
-if [ ! -f "$OPENCLAW_STATE_DIR/openclaw.json" ]; then
-	cat > "$OPENCLAW_STATE_DIR/openclaw.json" << 'EOFCONFIG'
+cat > "$OPENCLAW_STATE_DIR/openclaw.json" << 'EOFCONFIG'
 {
   "gateway": {
     "mode": "local",
@@ -117,7 +116,8 @@ if [ ! -f "$OPENCLAW_STATE_DIR/openclaw.json" ]; then
       "mode": "token"
     },
     "controlUi": {
-      "allowInsecureAuth": true
+      "allowInsecureAuth": true,
+      "allowedOrigins": ["https://open-flare.millennials-post-covid.com"]
     }
   },
   "browser": {
@@ -137,8 +137,7 @@ if [ ! -f "$OPENCLAW_STATE_DIR/openclaw.json" ]; then
   }
 }
 EOFCONFIG
-	echo "[INFO] Default config file created (local mode + allowInsecureAuth)"
-fi
+echo "[INFO] Config file written (local mode + allowInsecureAuth)"
 
 echo "[INFO] Starting OpenClaw Gateway..."
 echo "[INFO] Visit Web UI for initial setup on first use"

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,8 @@ cat > "$OPENCLAW_STATE_DIR/openclaw.json" << 'EOFCONFIG'
     },
     "controlUi": {
       "allowInsecureAuth": true,
-      "allowedOrigins": ["https://open-flare.millennials-post-covid.com"]
+      "allowedOrigins": ["https://open-flare.millennials-post-covid.com"],
+      "dangerouslyAllowHostHeaderOriginFallback": true
     }
   },
   "browser": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,18 @@ cd "$OPENCLAW_WORKSPACE_DIR"
 
 openclaw gateway --port 6658 --bind lan --allow-unconfigured &
 OPENCLAW_PID=$!
+
+# Auto-approve any pending device pairing requests. Cloudflare Containers has no
+# exec, and connections through the Worker are classified as "remote" by OpenClaw
+# (so silent local pairing is disabled). Access control is delegated to the
+# Worker's Basic Auth + Cloudflare Access in front of this container.
+(
+	while kill -0 "$OPENCLAW_PID" 2>/dev/null; do
+		sleep 5
+		openclaw devices approve --latest >/dev/null 2>&1 || true
+	done
+) &
+
 wait $OPENCLAW_PID
 EOF
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud Claw (Cloudflare + OpenClaw)
+# Cloud Claw (Cloudflare + OpenClaw) 
 
 **Cloud Claw** is a containerized AI assistant that runs [OpenClaw](https://github.com/openclaw/openclaw) on Cloudflare Workers + Containers.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "npm run lint"
   },
   "devDependencies": {
-    "@cloudflare/containers": "^0.1.0",
+    "@cloudflare/containers": "^0.3.2",
     "oxfmt": "^0.28.0",
     "oxlint": "^1.43.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@cloudflare/containers':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.3.2
+        version: 0.3.2
       oxfmt:
         specifier: ^0.28.0
         version: 0.28.0
@@ -26,8 +26,8 @@ importers:
 
 packages:
 
-  '@cloudflare/containers@0.1.0':
-    resolution: {integrity: sha512-nuXnmkpJZzbjYdguRI2hB0sw1QCBMWdNuGDNQwEiJSLebtKRFpBt/d6AStGjp+8wGD2plPbd2U/mQerYF9kzJg==}
+  '@cloudflare/containers@0.3.2':
+    resolution: {integrity: sha512-hWobJrpXCgFJ/HYii6E49eegnnlUDWGacjLd0Fb6nQwTD005+T2eHUPI6qOEq9KPJOd7xTWkhkuXEKxDFvfyqQ==}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -623,7 +623,7 @@ packages:
 
 snapshots:
 
-  '@cloudflare/containers@0.1.0': {}
+  '@cloudflare/containers@0.3.2': {}
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,6 +24,13 @@
       "custom_domain": true,
     },
   ],
+  "vars": {
+    "SERVER_USERNAME": "agili",
+    "WORKER_URL": "https://openrouter.millennials-post-covid.com",
+    "S3_ENDPOINT": "https://7018afd37571b2583d8b5866864e98fb.r2.cloudflarestorage.com",
+    "S3_BUCKET": "cloud-claw-data",
+    "S3_PREFIX": "cloud-claw",
+  },
   "browser": {
     "binding": "BROWSER",
     "remote": true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,13 +20,13 @@
   },
   "routes": [
     {
-      "pattern": "openrouter.millennials-post-covid.com",
+      "pattern": "open-flare.millennials-post-covid.com",
       "custom_domain": true,
     },
   ],
   "vars": {
     "SERVER_USERNAME": "agili",
-    "WORKER_URL": "https://openrouter.millennials-post-covid.com",
+    "WORKER_URL": "https://open-flare.millennials-post-covid.com",
     "S3_ENDPOINT": "https://7018afd37571b2583d8b5866864e98fb.r2.cloudflarestorage.com",
     "S3_BUCKET": "cloud-claw-data",
     "S3_PREFIX": "cloud-claw",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,6 +18,12 @@
   "placement": {
     "region": "aws:us-west-2",
   },
+  "routes": [
+    {
+      "pattern": "openrouter.millennials-post-covid.com",
+      "custom_domain": true,
+    },
+  ],
   "browser": {
     "binding": "BROWSER",
     "remote": true,


### PR DESCRIPTION
## Summary
- Cloudflare Containers has no `exec`, and OpenClaw classifies Worker-proxied connections as `remote` → silent local pairing is disabled, so first-time Control UI connections hang on `device pairing required`.
- Adds a background loop in the entrypoint that runs `openclaw devices approve --latest` every 5s for as long as the gateway is alive.
- Security model: the container sits behind the Worker's Basic Auth + Cloudflare Access, so delegating pairing trust to the network perimeter is acceptable here.

## Test plan
- [ ] GHA deploy succeeds
- [ ] Refreshing `https://open-flare.millennials-post-covid.com` and hitting Connect with the gateway token no longer returns `device pairing required`
- [ ] Subsequent reconnects are instant (token works without re-approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)